### PR TITLE
Supporting multiple zpools

### DIFF
--- a/scripts/zfs-snap-pac
+++ b/scripts/zfs-snap-pac
@@ -10,7 +10,7 @@ bootfs="none"
 snapshotName="zfs-snap-pac-1-"
 
 GetBootFS() {
-    bootfs=$(zpool get bootfs -o value -pH)
+    bootfs=$(zpool get bootfs -o value -pH | grep -v '-' | tail -n1)
 }
 
 GetSnapshotName() {


### PR DESCRIPTION
Skipping `-` values for `bootfs` and only grab the last one.

Output of `zpool get bootfs` on my system:
```
NAME      PROPERTY  VALUE         SOURCE
z8        bootfs    z8/ROOT/arch  local
zcorsair  bootfs    -             default
```
Doing this with `-o value -pH` makes it:
```
z8/ROOT/arch
-
```
Explicitly removing blank values with `| grep -v '-'`:
```
z8/ROOT/arch
```
And `| tail -n1` in case there are multiple remaining. I previously used just `| tail -n1` when my pool names were different, the `grep -v '-'` fixes most of the issues, but the `tail` is there just in case.